### PR TITLE
chore: add clang-format pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.8
+    hooks:
+      - id: clang-format
+        types_or: [c, c++]


### PR DESCRIPTION
## Summary
- run clang-format through pre-commit

## Testing
- `pre-commit run --files src/pointcloud2.cpp src/pointcloud_tool.cpp include/pointcloud2.hpp tests/test_pointcloud2.cpp`
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_689fadf474fc8328a5ea3b5e70edf6f0