### PR TITLE
Run clang-format via pre-commit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y g++ cmake clang-format
-      - name: Clang-format
-        run: clang-format --dry-run --Werror $(git ls-files '*.hpp' '*.cpp')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ cmake clang-format python3-pip
+          pip install pre-commit
+      - name: pre-commit
+        run: pre-commit run --files $(git ls-files '*.hpp' '*.cpp')
       - name: Configure
         run: cmake -B build -S .
       - name: Build

--- a/src/pointcloud_tool.cpp
+++ b/src/pointcloud_tool.cpp
@@ -1,7 +1,6 @@
 #include <spdlog/spdlog.h>
 
 #include <cstring>
-
 #include <mcap/reader.hpp>
 #include <mcap/writer.hpp>
 

--- a/tests/test_mcap.cpp
+++ b/tests/test_mcap.cpp
@@ -1,7 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
-#include <cstring>
 #include <cstdio>
-
+#include <cstring>
 #include <mcap/reader.hpp>
 #include <mcap/writer.hpp>
 


### PR DESCRIPTION
## Summary
- format source and test files using pre-commit clang-format
- switch CI formatting step to pre-commit

## Testing
- `pre-commit run --all-files`
- `cmake -B build -S .`
- `cmake --build build` *(fails: interrupted)*
- `ctest --test-dir build --output-on-failure` *(fails: executables not found)*

------
https://chatgpt.com/codex/tasks/task_b_689fb04768708328961adfaebc80fbc5