### PR TITLE
Add option for static or shared builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ project(pointcloud_tool)
 
 set(CMAKE_CXX_STANDARD 17)
 
+# Option to control whether to build shared or static libraries.
+# By default we build static libraries so the final executable can be a
+# self-contained binary without external `.so` dependencies. Users can enable
+# shared libraries via `-DBUILD_SHARED_LIBS=ON`.
+option(BUILD_SHARED_LIBS "Build project libraries as shared" OFF)
+
 include(FetchContent)
 
 FetchContent_Declare(

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ cmake ..
 make
 ```
 
+The default build links all project components statically so `pointcloud_tool`
+does not depend on accompanying `.so` files. If shared libraries are desired,
+enable them explicitly when configuring CMake:
+
+```bash
+cmake -DBUILD_SHARED_LIBS=ON ..
+```
+
 Run unit tests:
 
 ```bash


### PR DESCRIPTION
## Summary
- switch to standard `BUILD_SHARED_LIBS` option for shared/static builds
- document how to enable shared libraries at configure time

## Testing
- `pre-commit run --files CMakeLists.txt README.md`
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_b_689fe63b50588328ab849ad699ce7611