### PR TITLE
Run CI only for PR opens and updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- avoid duplicate builds by removing `push` trigger
- run CI only when a PR is opened or updated

## Testing
- `pre-commit run --files $(git ls-files '*.hpp' '*.cpp')`
- `cmake -B build -S .`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_689fee972c8083288ca7227892c06e06